### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,11 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Intended Audience :: Developers"
-    )
+    ),
+    install_requires=[
+        'APScheduler',
+        'requests',
+        'uptime',
+        'urllib3'
+    ]
 )


### PR DESCRIPTION
This would allow openhim-mediator-utils-py to be installed along with its requirements using
```bash
    $ pip install git+https://github.com/de-laz/openhim-mediator-utils-py.git@development#egg=openhim-mediator-utils
```

For more details and a comparison with `requirements.txt`, see the [Python Packaging User Guide](https://packaging.python.org/discussions/install-requires-vs-requirements/).
